### PR TITLE
Web Console Bug Fixes

### DIFF
--- a/backend/src/main.go
+++ b/backend/src/main.go
@@ -35,8 +35,14 @@ func main() {
 		// Run them as goroutines so the serer start up is faster
 		go func(server database.Server) {
 			log.Printf("Restarting server %d since it is supposed to be started", *server.ID)
-			_ = utils.StopServer(*server.ID)
-			err := utils.StartServer(*server.ID)
+
+			// Lock on restart
+			lock := utils.GetLock(*server.ID)
+			lock.Lock()
+			_ = utils.StopServer(*server.ID, false)
+			err := utils.StartServer(*server.ID, false)
+			lock.Unlock()
+
 			// TODO come up with a solution to remedy this
 			if err != nil {
 				log.Printf("Server %d no longer exists in docker\n", *server.ID)

--- a/backend/src/routes/discord.go
+++ b/backend/src/routes/discord.go
@@ -127,7 +127,7 @@ func MakeIntegration(w http.ResponseWriter, r *http.Request) {
 
 	if integration.Active == false && active == true {
 		// Integration wasn't started before, but should be now, so start it
-		connDetails := utils.AttachServer(serverID)
+		connDetails, _ := utils.AttachServer(serverID, nil)
 		database.DB.Table("discord_integrations").Where(
 			"server_id = ?", serverID,
 		).Update("active", true)

--- a/backend/src/routes/websocket.go
+++ b/backend/src/routes/websocket.go
@@ -53,7 +53,7 @@ func WsServerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get the connection details
-	connDetails := utils.AttachServer(serverID)
+	connDetails, _ := utils.AttachServer(serverID, nil)
 
 	// Upgrade the http connection to a websocket
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -147,7 +147,6 @@ func WsServerHandler(w http.ResponseWriter, r *http.Request) {
 				for c, pipes := range connDetails.SPMC {
 					// If a connection is not in no repeat, send the message
 					_, exists := connDetails.NoRepeat[c]
-					log.Println(c)
 					if !exists || (c != nil && conn != c) {
 						pipes.StdoutChan <- data
 					}

--- a/backend/src/utils/docker.go
+++ b/backend/src/utils/docker.go
@@ -88,7 +88,6 @@ func GetLock(serverID int) (lock *sync.Mutex) {
 
 // ServerConsole handles communication between the websocket and the channels
 func ServerConsole(connDetails *ConnDetails, console *Console) {
-	log.Println("Route Console")
 	go func(connDetails *ConnDetails, console *Console) {
 		w := console.Stdin
 		// Forever write into stdin
@@ -115,7 +114,6 @@ func ServerConsole(connDetails *ConnDetails, console *Console) {
 				// Server closed normally
 				if err == io.EOF {
 					// If the pipes are the old ones, remove them
-					log.Println("Route Die 1", connDetails.Pipes == console)
 					if connDetails.Pipes == console {
 						connDetails.Pipes = nil
 					}
@@ -135,9 +133,7 @@ func ServerConsole(connDetails *ConnDetails, console *Console) {
 				if connDetails.Pipes == console {
 					connDetails.Pipes = nil
 				}
-				log.Println("Here")
 
-				log.Println("Route Die 2", connDetails.Pipes == console)
 				// We are done, unlock and kill this function
 				lock.Unlock()
 				return
@@ -317,7 +313,6 @@ func StartServer(serverID int, shouldLock bool) (err error) {
 
 	// Get the connection details
 	connDetails, exists := AttachServer(serverID, &console)
-	log.Println("Route Start")
 
 	// If the console didn't already exist before
 	if !exists {
@@ -336,6 +331,7 @@ func StartServer(serverID int, shouldLock bool) (err error) {
 		// Stop the lock
 		lock.Unlock()
 	}
+
 	return err
 }
 
@@ -354,7 +350,6 @@ func StopServer(serverID int, shouldLock bool) (err error) {
 	// Remove the console associated with an attached server
 	connDetails, _ := AttachServer(serverID, nil)
 	connDetails.Pipes = nil
-	log.Println("Route Stop")
 
 	// Stop the server
 	err = cmd.Run()


### PR DESCRIPTION
Did my best to fix all race conditions with the console and the docker containers. It appears the docker engine will sometimes report a container is stopped when it hasn't actually stopped if you send it too many requests in too short of a time. I cannot tell if this is a docker bug or not. The console is probably as race free as it can be right now. Use it like a sane person and don't send too many requests at once. Then you will have no issues.